### PR TITLE
Fixing error "charmap' codec can't encode character '

### DIFF
--- a/opendota/opendota.py
+++ b/opendota/opendota.py
@@ -241,7 +241,7 @@ class OpenDota:
             return None
 
         if path is not None:
-            with open(path, "w") as f:
+            with open(path, "w", encoding='utf-8') as f:
                 json.dump(json_data, f, ensure_ascii=False)
         return json_data
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
tried to get match details but was encountering charmap error.
 
client.get_match('6763284976')


<!--- Describe your changes in detail -->

## Motivation and Context
to solve the issue encountered regarding charmap code

## How has this been tested?
Upon adding the utf-8 encoding support, the error went away, and I can now call the method

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ x] Bug fix (non-breaking change which fixes an issue)